### PR TITLE
feat: MCP tag assignment, enrichment defaults, cocktail edit UI

### DIFF
--- a/backend/app/routers/bottles.py
+++ b/backend/app/routers/bottles.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.database import get_db
-from app.models.bottle import Bottle, BottleStatus, BottleType
+from app.models.bottle import Bottle, BottleStatus, BottleType, EnrichmentStatus
 from app.models.tag import Tag
 from app.schemas.bottle import BottleCreate, BottleOut, BottleUpdate, QuantityAdjust
 
@@ -57,10 +57,22 @@ def get_bottle(bottle_id: str, db: Session = Depends(get_db)):
     return bottle
 
 
+# Key enrichment fields — if 3+ are filled, the bottle is considered complete
+_ENRICHMENT_FIELDS = ("producer", "region", "country", "grape_or_base", "abv")
+_ENRICHMENT_THRESHOLD = 3
+
+
 @router.post("", response_model=BottleOut, status_code=201)
 def create_bottle(data: BottleCreate, db: Session = Depends(get_db)):
     fields = data.model_dump(exclude={"tag_ids"})
     fields["quantity_purchased"] = data.quantity
+
+    # Auto-detect enrichment status if not explicitly set
+    if data.enrichment_status is None:
+        filled = sum(1 for f in _ENRICHMENT_FIELDS if fields.get(f) is not None)
+        if filled >= _ENRICHMENT_THRESHOLD:
+            fields["enrichment_status"] = EnrichmentStatus.confirmed
+
     bottle = Bottle(**fields)
     if data.tag_ids:
         tags = db.query(Tag).filter(Tag.id.in_(data.tag_ids)).all()

--- a/backend/app/routers/bottles.py
+++ b/backend/app/routers/bottles.py
@@ -69,7 +69,7 @@ def create_bottle(data: BottleCreate, db: Session = Depends(get_db)):
 
     # Auto-detect enrichment status if not explicitly set
     if data.enrichment_status is None:
-        filled = sum(fields.get(f) is not None for f in _ENRICHMENT_FIELDS)
+        filled = sum(bool(fields.get(f)) for f in _ENRICHMENT_FIELDS)
         if filled >= _ENRICHMENT_THRESHOLD:
             fields["enrichment_status"] = EnrichmentStatus.confirmed
 

--- a/backend/app/routers/bottles.py
+++ b/backend/app/routers/bottles.py
@@ -69,7 +69,7 @@ def create_bottle(data: BottleCreate, db: Session = Depends(get_db)):
 
     # Auto-detect enrichment status if not explicitly set
     if data.enrichment_status is None:
-        filled = sum(1 for f in _ENRICHMENT_FIELDS if fields.get(f) is not None)
+        filled = sum(fields.get(f) is not None for f in _ENRICHMENT_FIELDS)
         if filled >= _ENRICHMENT_THRESHOLD:
             fields["enrichment_status"] = EnrichmentStatus.confirmed
 

--- a/backend/app/schemas/bottle.py
+++ b/backend/app/schemas/bottle.py
@@ -59,6 +59,7 @@ class BottleCreate(BaseModel):
     purchase_date: date | None = None
     source_shop: str | None = None
     barcode: str | None = None
+    enrichment_status: EnrichmentStatus | None = None
     serving_temp: str | None = None
     drink_window_start: date | None = None
     drink_window_end: date | None = None

--- a/backend/tests/test_bottles.py
+++ b/backend/tests/test_bottles.py
@@ -44,3 +44,28 @@ def test_search_bottles(client):
     client.post("/api/bottles", json={"name": "Château Margaux", "type": "wine", "quantity": 1})
     r = client.get("/api/bottles?search=margaux")
     assert len(r.json()) >= 1
+
+
+def test_create_bottle_minimal_defaults_to_pending(client):
+    """Bottles with just name+type should be pending enrichment."""
+    r = client.post("/api/bottles", json={"name": "Mystery Wine", "type": "wine", "quantity": 1})
+    assert r.json()["enrichment_status"] == "pending"
+
+
+def test_create_bottle_complete_defaults_to_confirmed(client):
+    """Bottles with enough fields filled should auto-confirm."""
+    r = client.post("/api/bottles", json={
+        "name": "Barolo Riserva", "type": "wine", "quantity": 1,
+        "producer": "Giacomo Conterno", "region": "Piedmont", "country": "Italy",
+        "grape_or_base": "Nebbiolo", "abv": 14.0,
+    })
+    assert r.json()["enrichment_status"] == "confirmed"
+
+
+def test_create_bottle_explicit_enrichment_status_overrides(client):
+    """Explicit enrichment_status should always win, even for incomplete bottles."""
+    r = client.post("/api/bottles", json={
+        "name": "Quick Add", "type": "spirit", "quantity": 1,
+        "enrichment_status": "manual",
+    })
+    assert r.json()["enrichment_status"] == "manual"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import BottleDetail from './pages/BottleDetail';
 import QuickAdd from './pages/QuickAdd';
 import NewTasting from './pages/NewTasting';
 import NewCocktail from './pages/NewCocktail';
+import EditCocktail from './pages/EditCocktail';
 import Pantry from './pages/Pantry';
 
 export default function App() {
@@ -44,6 +45,7 @@ export default function App() {
               <Route path="/tastings/new" element={<NewTasting />} />
               <Route path="/cocktails" element={<Cocktails />} />
               <Route path="/cocktails/new" element={<NewCocktail />} />
+              <Route path="/cocktails/:id/edit" element={<EditCocktail />} />
               <Route path="/shopping" element={<ShoppingList />} />
               <Route path="/pantry" element={<Pantry />} />
               <Route path="*" element={<Navigate to="/" />} />

--- a/frontend/src/pages/Cocktails.tsx
+++ b/frontend/src/pages/Cocktails.tsx
@@ -275,7 +275,13 @@ export default function Cocktails() {
                       </div>
                     )}
 
-                    <div className="pt-2">
+                    <div className="pt-2 flex items-center gap-4">
+                      <Link
+                        to={`/cocktails/${recipe.id}/edit`}
+                        className="text-xs text-amber-700 hover:text-amber-900 font-medium"
+                      >
+                        Edit recipe
+                      </Link>
                       <button
                         onClick={() => handleDelete(recipe.id)}
                         className="text-xs text-red-600 hover:text-red-800"

--- a/frontend/src/pages/EditCocktail.tsx
+++ b/frontend/src/pages/EditCocktail.tsx
@@ -57,7 +57,7 @@ export default function EditCocktail() {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    if (!id) {
+    if (!id || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
       setError('Cocktail ID not found.');
       setLoading(false);
       return;
@@ -77,15 +77,15 @@ export default function EditCocktail() {
         setDifficulty(cocktail.difficulty || '');
         setNotes(cocktail.notes || '');
         if (cocktail.ingredients.length > 0) {
-          setIngredients(
-            cocktail.ingredients.map(ing => ({
-              key: nextKeyRef.current++,
-              name: ing.name,
-              amount_cl: ing.amount_cl != null ? String(ing.amount_cl) : '',
-              tag_id: ing.tag?.id || '',
-              is_pantry_item: ing.is_pantry_item,
-            })),
-          );
+          const initialIngredients = cocktail.ingredients.map((ing, i) => ({
+            key: i,
+            name: ing.name,
+            amount_cl: ing.amount_cl != null ? String(ing.amount_cl) : '',
+            tag_id: ing.tag?.id || '',
+            is_pantry_item: ing.is_pantry_item,
+          }));
+          setIngredients(initialIngredients);
+          nextKeyRef.current = initialIngredients.length;
         }
       })
       .catch(err => {

--- a/frontend/src/pages/EditCocktail.tsx
+++ b/frontend/src/pages/EditCocktail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { api } from '../api/client';
 
@@ -34,15 +34,15 @@ interface CocktailData {
   }[];
 }
 
-let nextKey = 0;
-
-function emptyIngredient(): IngredientRow {
-  return { key: nextKey++, name: '', amount_cl: '', tag_id: '', is_pantry_item: false };
-}
-
 export default function EditCocktail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const nextKeyRef = useRef(0);
+
+  function emptyIngredient(): IngredientRow {
+    return { key: nextKeyRef.current++, name: '', amount_cl: '', tag_id: '', is_pantry_item: false };
+  }
+
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [method, setMethod] = useState('');
@@ -57,6 +57,12 @@ export default function EditCocktail() {
   const [error, setError] = useState('');
 
   useEffect(() => {
+    if (!id) {
+      setError('Cocktail ID not found.');
+      setLoading(false);
+      return;
+    }
+
     Promise.all([
       api.get<Tag[]>('/tags?category=ingredient'),
       api.get<CocktailData>(`/cocktails/${id}`),
@@ -73,7 +79,7 @@ export default function EditCocktail() {
         if (cocktail.ingredients.length > 0) {
           setIngredients(
             cocktail.ingredients.map(ing => ({
-              key: nextKey++,
+              key: nextKeyRef.current++,
               name: ing.name,
               amount_cl: ing.amount_cl != null ? String(ing.amount_cl) : '',
               tag_id: ing.tag?.id || '',

--- a/frontend/src/pages/EditCocktail.tsx
+++ b/frontend/src/pages/EditCocktail.tsx
@@ -82,7 +82,10 @@ export default function EditCocktail() {
           );
         }
       })
-      .catch(console.error)
+      .catch(err => {
+        console.error(err);
+        setError('Failed to load recipe');
+      })
       .finally(() => setLoading(false));
   }, [id]);
 

--- a/frontend/src/pages/EditCocktail.tsx
+++ b/frontend/src/pages/EditCocktail.tsx
@@ -1,0 +1,323 @@
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams, Link } from 'react-router-dom';
+import { api } from '../api/client';
+
+interface Tag {
+  id: string;
+  name: string;
+  category: string;
+}
+
+interface IngredientRow {
+  key: number;
+  name: string;
+  amount_cl: string;
+  tag_id: string;
+  is_pantry_item: boolean;
+}
+
+interface CocktailData {
+  id: string;
+  name: string;
+  description: string | null;
+  method: string | null;
+  glass_type: string | null;
+  garnish: string | null;
+  difficulty: string | null;
+  notes: string | null;
+  ingredients: {
+    id: string;
+    name: string;
+    amount_cl: number | null;
+    tag: { id: string; name: string; category: string } | null;
+    is_pantry_item: boolean;
+  }[];
+}
+
+let nextKey = 0;
+
+function emptyIngredient(): IngredientRow {
+  return { key: nextKey++, name: '', amount_cl: '', tag_id: '', is_pantry_item: false };
+}
+
+export default function EditCocktail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [method, setMethod] = useState('');
+  const [glassType, setGlassType] = useState('');
+  const [garnish, setGarnish] = useState('');
+  const [difficulty, setDifficulty] = useState('');
+  const [notes, setNotes] = useState('');
+  const [ingredients, setIngredients] = useState<IngredientRow[]>([emptyIngredient()]);
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    Promise.all([
+      api.get<Tag[]>('/tags?category=ingredient'),
+      api.get<CocktailData>(`/cocktails/${id}`),
+    ])
+      .then(([tagList, cocktail]) => {
+        setTags(tagList);
+        setName(cocktail.name);
+        setDescription(cocktail.description || '');
+        setMethod(cocktail.method || '');
+        setGlassType(cocktail.glass_type || '');
+        setGarnish(cocktail.garnish || '');
+        setDifficulty(cocktail.difficulty || '');
+        setNotes(cocktail.notes || '');
+        if (cocktail.ingredients.length > 0) {
+          setIngredients(
+            cocktail.ingredients.map(ing => ({
+              key: nextKey++,
+              name: ing.name,
+              amount_cl: ing.amount_cl != null ? String(ing.amount_cl) : '',
+              tag_id: ing.tag?.id || '',
+              is_pantry_item: ing.is_pantry_item,
+            })),
+          );
+        }
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  function updateIngredient(key: number, field: keyof IngredientRow, value: string | boolean) {
+    setIngredients(prev =>
+      prev.map(ing => (ing.key === key ? { ...ing, [field]: value } : ing)),
+    );
+  }
+
+  function addIngredient() {
+    setIngredients(prev => [...prev, emptyIngredient()]);
+  }
+
+  function removeIngredient(key: number) {
+    setIngredients(prev => {
+      if (prev.length <= 1) return prev;
+      return prev.filter(ing => ing.key !== key);
+    });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError('Name is required');
+      return;
+    }
+
+    const validIngredients = ingredients
+      .filter(ing => ing.name.trim())
+      .map(ing => ({
+        name: ing.name.trim(),
+        amount_cl: ing.amount_cl ? parseFloat(ing.amount_cl) : null,
+        tag_id: ing.tag_id || null,
+        is_pantry_item: ing.is_pantry_item,
+      }));
+
+    setSubmitting(true);
+    setError('');
+
+    try {
+      await api.patch(`/cocktails/${id}`, {
+        name: name.trim(),
+        description: description.trim() || null,
+        method: method || null,
+        glass_type: glassType.trim() || null,
+        garnish: garnish.trim() || null,
+        difficulty: difficulty || null,
+        notes: notes.trim() || null,
+        ingredients: validIngredients,
+      });
+      navigate('/cocktails');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update recipe');
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return <p className="text-stone-500 text-sm">Loading recipe...</p>;
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <Link to="/cocktails" className="text-amber-700 hover:underline text-sm">
+        &larr; Back to cocktails
+      </Link>
+
+      <h1 className="text-2xl font-bold mt-3 mb-4">Edit Cocktail Recipe</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {error && (
+          <p className="text-red-600 text-sm bg-red-50 p-2 rounded">{error}</p>
+        )}
+
+        {/* Name */}
+        <div>
+          <label className="block text-sm font-medium text-stone-700 mb-1">
+            Name <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            className="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+            required
+          />
+        </div>
+
+        {/* Description */}
+        <div>
+          <label className="block text-sm font-medium text-stone-700 mb-1">Description</label>
+          <textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            rows={2}
+            className="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+          />
+        </div>
+
+        {/* Method & Difficulty */}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-stone-700 mb-1">Method</label>
+            <select
+              value={method}
+              onChange={e => setMethod(e.target.value)}
+              className="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+            >
+              <option value="">-- Select --</option>
+              <option value="shake">Shake</option>
+              <option value="stir">Stir</option>
+              <option value="build">Build</option>
+              <option value="blend">Blend</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-stone-700 mb-1">Difficulty</label>
+            <select
+              value={difficulty}
+              onChange={e => setDifficulty(e.target.value)}
+              className="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+            >
+              <option value="">-- Select --</option>
+              <option value="easy">Easy</option>
+              <option value="medium">Medium</option>
+              <option value="advanced">Advanced</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Glass type & Garnish */}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-stone-700 mb-1">Glass Type</label>
+            <input
+              type="text"
+              value={glassType}
+              onChange={e => setGlassType(e.target.value)}
+              className="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-stone-700 mb-1">Garnish</label>
+            <input
+              type="text"
+              value={garnish}
+              onChange={e => setGarnish(e.target.value)}
+              className="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+            />
+          </div>
+        </div>
+
+        {/* Ingredients */}
+        <div>
+          <label className="block text-sm font-medium text-stone-700 mb-2">Ingredients</label>
+          <div className="space-y-2">
+            {ingredients.map((ing, idx) => (
+              <div key={ing.key} className="flex gap-2 items-start bg-stone-50 rounded-lg p-2 border border-stone-100">
+                <div className="text-xs text-stone-400 mt-2 w-4 text-center shrink-0">{idx + 1}</div>
+                <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <input
+                    type="text"
+                    value={ing.name}
+                    onChange={e => updateIngredient(ing.key, 'name', e.target.value)}
+                    placeholder="Ingredient name"
+                    className="border border-stone-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  />
+                  <input
+                    type="number"
+                    value={ing.amount_cl}
+                    onChange={e => updateIngredient(ing.key, 'amount_cl', e.target.value)}
+                    placeholder="Amount (cl)"
+                    min="0"
+                    step="0.5"
+                    className="border border-stone-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  />
+                  <select
+                    value={ing.tag_id}
+                    onChange={e => updateIngredient(ing.key, 'tag_id', e.target.value)}
+                    className="border border-stone-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+                  >
+                    <option value="">-- Tag (optional) --</option>
+                    {tags.map(t => (
+                      <option key={t.id} value={t.id}>{t.name}</option>
+                    ))}
+                  </select>
+                  <label className="inline-flex items-center gap-1.5 text-sm text-stone-600 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={ing.is_pantry_item}
+                      onChange={e => updateIngredient(ing.key, 'is_pantry_item', e.target.checked)}
+                      className="w-4 h-4 rounded border-stone-300 text-amber-600 focus:ring-amber-500"
+                    />
+                    Pantry item
+                  </label>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => removeIngredient(ing.key)}
+                  className="text-stone-400 hover:text-red-600 text-sm mt-1 shrink-0 px-1"
+                  title="Remove ingredient"
+                >
+                  &times;
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={addIngredient}
+            className="mt-2 text-sm text-amber-700 hover:text-amber-900 font-medium"
+          >
+            + Add ingredient
+          </button>
+        </div>
+
+        {/* Notes */}
+        <div>
+          <label className="block text-sm font-medium text-stone-700 mb-1">Notes</label>
+          <textarea
+            value={notes}
+            onChange={e => setNotes(e.target.value)}
+            rows={2}
+            className="w-full border border-stone-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full bg-amber-600 hover:bg-amber-700 disabled:bg-amber-400 text-white px-4 py-2.5 rounded font-medium text-sm"
+        >
+          {submitting ? 'Saving...' : 'Save Changes'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/NewCocktail.tsx
+++ b/frontend/src/pages/NewCocktail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { api } from '../api/client';
 
@@ -16,14 +16,14 @@ interface IngredientRow {
   is_pantry_item: boolean;
 }
 
-let nextKey = 0;
-
-function emptyIngredient(): IngredientRow {
-  return { key: nextKey++, name: '', amount_cl: '', tag_id: '', is_pantry_item: false };
-}
-
 export default function NewCocktail() {
   const navigate = useNavigate();
+  const nextKeyRef = useRef(0);
+
+  function emptyIngredient(): IngredientRow {
+    return { key: nextKeyRef.current++, name: '', amount_cl: '', tag_id: '', is_pantry_item: false };
+  }
+
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [method, setMethod] = useState('');

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -4,8 +4,16 @@
 # ///
 
 import os
+import re
 import httpx
 from fastmcp import FastMCP
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+
+
+def _validate_uuid(value: str, name: str = "id") -> None:
+    if not _UUID_RE.match(value):
+        raise ValueError(f"Invalid {name}: must be a UUID")
 
 BACKEND_URL = os.environ.get("BACKEND_URL", "http://localhost:5177")
 
@@ -107,6 +115,7 @@ def search_bottles(
 @mcp.tool
 def get_bottle(bottle_id: str) -> dict:
     """Get full details for a specific bottle by ID."""
+    _validate_uuid(bottle_id, "bottle_id")
     return _get(f"/api/bottles/{bottle_id}")
 
 
@@ -138,12 +147,10 @@ def add_bottle(
     data = {"name": name, "type": type, "quantity": quantity}
     for field in ["purchase_price_kr", "producer", "subtype", "vintage", "region",
                   "country", "grape_or_base", "abv", "volume_ml", "barcode", "notes",
-                  "serving_temp", "suggested_pairings", "enrichment_status"]:
+                  "serving_temp", "suggested_pairings", "enrichment_status", "tag_ids"]:
         val = locals()[field]
         if val is not None:
             data[field] = val
-    if tag_ids is not None:
-        data["tag_ids"] = tag_ids
     return _post("/api/bottles", json=data)
 
 
@@ -172,27 +179,28 @@ def update_bottle(
     """Update any fields on a bottle. Pass only the fields you want to change.
     Type: wine/spirit/liqueur/beer/other. Status: in_stock/consumed/gifted.
     tag_ids: list of tag UUIDs to assign (replaces existing tags)."""
+    _validate_uuid(bottle_id, "bottle_id")
     updates = {}
     for field in ["name", "producer", "type", "subtype", "vintage", "region", "country",
                   "grape_or_base", "abv", "volume_ml", "purchase_price_kr", "barcode",
-                  "notes", "serving_temp", "suggested_pairings", "enrichment_status", "status"]:
+                  "notes", "serving_temp", "suggested_pairings", "enrichment_status", "status", "tag_ids"]:
         val = locals()[field]
         if val is not None:
             updates[field] = val
-    if tag_ids is not None:
-        updates["tag_ids"] = tag_ids
     return _patch(f"/api/bottles/{bottle_id}", json=updates)
 
 
 @mcp.tool
 def adjust_quantity(bottle_id: str, quantity: float) -> dict:
     """Adjust a bottle's quantity. Set to 0 to mark as consumed."""
+    _validate_uuid(bottle_id, "bottle_id")
     return _post(f"/api/bottles/{bottle_id}/adjust", json={"quantity": quantity})
 
 
 @mcp.tool
 def delete_bottle(bottle_id: str) -> dict:
     """Permanently delete a bottle from the collection."""
+    _validate_uuid(bottle_id, "bottle_id")
     return _delete(f"/api/bottles/{bottle_id}")
 
 
@@ -457,14 +465,13 @@ def enrich_bottle(
     """Update a bottle with enrichment data after researching it.
     Call this after getting user confirmation. Sets enrichment_status to 'claude_enriched'.
     tag_ids: list of tag UUIDs for ingredient/flavor tags (enables cocktail matching)."""
+    _validate_uuid(bottle_id, "bottle_id")
     data = {"enrichment_status": "claude_enriched"}
     for field in ["producer", "region", "country", "grape_or_base", "abv",
-                  "volume_ml", "subtype", "serving_temp", "suggested_pairings", "notes"]:
+                  "volume_ml", "subtype", "serving_temp", "suggested_pairings", "notes", "tag_ids"]:
         val = locals()[field]
         if val is not None:
             data[field] = val
-    if tag_ids is not None:
-        data["tag_ids"] = tag_ids
     return _patch(f"/api/bottles/{bottle_id}", json=data)
 
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -15,6 +15,12 @@ def _validate_uuid(value: str, name: str = "id") -> None:
     if not _UUID_RE.match(value):
         raise ValueError(f"Invalid {name}: must be a UUID")
 
+
+def _validate_tag_ids(tag_ids: list[str] | None) -> None:
+    if tag_ids:
+        for tid in tag_ids:
+            _validate_uuid(tid, "tag_id")
+
 BACKEND_URL = os.environ.get("BACKEND_URL", "http://localhost:5177")
 
 mcp = FastMCP(
@@ -144,6 +150,7 @@ def add_bottle(
     Only name and type are required; fill in what you know.
     tag_ids: list of tag UUIDs to assign (ingredient/flavor/type tags for cocktail matching).
     Set enrichment_status to 'manual' or 'confirmed' to skip the enrichment queue."""
+    _validate_tag_ids(tag_ids)
     data = {"name": name, "type": type, "quantity": quantity}
     for field in ["purchase_price_kr", "producer", "subtype", "vintage", "region",
                   "country", "grape_or_base", "abv", "volume_ml", "barcode", "notes",
@@ -180,6 +187,7 @@ def update_bottle(
     Type: wine/spirit/liqueur/beer/other. Status: in_stock/consumed/gifted.
     tag_ids: list of tag UUIDs to assign (replaces existing tags)."""
     _validate_uuid(bottle_id, "bottle_id")
+    _validate_tag_ids(tag_ids)
     updates = {}
     for field in ["name", "producer", "type", "subtype", "vintage", "region", "country",
                   "grape_or_base", "abv", "volume_ml", "purchase_price_kr", "barcode",
@@ -466,6 +474,7 @@ def enrich_bottle(
     Call this after getting user confirmation. Sets enrichment_status to 'claude_enriched'.
     tag_ids: list of tag UUIDs for ingredient/flavor tags (enables cocktail matching)."""
     _validate_uuid(bottle_id, "bottle_id")
+    _validate_tag_ids(tag_ids)
     data = {"enrichment_status": "claude_enriched"}
     for field in ["producer", "region", "country", "grape_or_base", "abv",
                   "volume_ml", "subtype", "serving_temp", "suggested_pairings", "notes", "tag_ids"]:

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -129,9 +129,11 @@ def add_bottle(
     serving_temp: str | None = None,
     suggested_pairings: str | None = None,
     enrichment_status: str | None = None,
+    tag_ids: list[str] | None = None,
 ) -> dict:
     """Add a new bottle to the collection. Type must be: wine, spirit, liqueur, beer, or other.
     Only name and type are required; fill in what you know.
+    tag_ids: list of tag UUIDs to assign (ingredient/flavor/type tags for cocktail matching).
     Set enrichment_status to 'manual' or 'confirmed' to skip the enrichment queue."""
     data = {"name": name, "type": type, "quantity": quantity}
     for field in ["purchase_price_kr", "producer", "subtype", "vintage", "region",
@@ -140,6 +142,8 @@ def add_bottle(
         val = locals()[field]
         if val is not None:
             data[field] = val
+    if tag_ids is not None:
+        data["tag_ids"] = tag_ids
     return _post("/api/bottles", json=data)
 
 
@@ -163,9 +167,11 @@ def update_bottle(
     suggested_pairings: str | None = None,
     enrichment_status: str | None = None,
     status: str | None = None,
+    tag_ids: list[str] | None = None,
 ) -> dict:
     """Update any fields on a bottle. Pass only the fields you want to change.
-    Type: wine/spirit/liqueur/beer/other. Status: in_stock/consumed/gifted."""
+    Type: wine/spirit/liqueur/beer/other. Status: in_stock/consumed/gifted.
+    tag_ids: list of tag UUIDs to assign (replaces existing tags)."""
     updates = {}
     for field in ["name", "producer", "type", "subtype", "vintage", "region", "country",
                   "grape_or_base", "abv", "volume_ml", "purchase_price_kr", "barcode",
@@ -173,6 +179,8 @@ def update_bottle(
         val = locals()[field]
         if val is not None:
             updates[field] = val
+    if tag_ids is not None:
+        updates["tag_ids"] = tag_ids
     return _patch(f"/api/bottles/{bottle_id}", json=updates)
 
 
@@ -444,15 +452,19 @@ def enrich_bottle(
     serving_temp: str | None = None,
     suggested_pairings: str | None = None,
     notes: str | None = None,
+    tag_ids: list[str] | None = None,
 ) -> dict:
     """Update a bottle with enrichment data after researching it.
-    Call this after getting user confirmation. Sets enrichment_status to 'claude_enriched'."""
+    Call this after getting user confirmation. Sets enrichment_status to 'claude_enriched'.
+    tag_ids: list of tag UUIDs for ingredient/flavor tags (enables cocktail matching)."""
     data = {"enrichment_status": "claude_enriched"}
     for field in ["producer", "region", "country", "grape_or_base", "abv",
                   "volume_ml", "subtype", "serving_temp", "suggested_pairings", "notes"]:
         val = locals()[field]
         if val is not None:
             data[field] = val
+    if tag_ids is not None:
+        data["tag_ids"] = tag_ids
     return _patch(f"/api/bottles/{bottle_id}", json=data)
 
 


### PR DESCRIPTION
## Summary

Fixes three open issues:

- **#5 — MCP tag assignment on bottles**: Added `tag_ids` parameter to `add_bottle`, `update_bottle`, and `enrich_bottle` MCP tools. Backend already supported it; this closes the MCP passthrough gap.
- **#6 — Smarter enrichment defaults**: Bottles created with 3+ key fields (producer, region, country, grape_or_base, abv) now auto-default to `confirmed` instead of `pending`. Explicit `enrichment_status` always takes precedence.
- **#8 — Cocktail edit UI**: New `EditCocktail.tsx` page with pre-populated form, PATCH submission, route at `/cocktails/:id/edit`, and "Edit recipe" link in the cocktail list.

## Test plan

- [x] 33/33 backend tests pass (3 new tests for enrichment auto-detection)
- [x] TypeScript compiles with no errors
- [ ] Manual: Create a bottle via MCP with `tag_ids` — verify tags appear
- [ ] Manual: Create a minimal bottle — verify `enrichment_status` is `pending`
- [ ] Manual: Create a bottle with producer+region+country+grape+abv — verify `confirmed`
- [ ] Manual: Open a cocktail, click "Edit recipe", modify fields, save — verify changes persist

Closes #5, closes #6, closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)